### PR TITLE
[13.0][ADD] mason_production_statistic

### DIFF
--- a/custom-addons/mason_mrp_workorder/models/mrp_workcenter.py
+++ b/custom-addons/mason_mrp_workorder/models/mrp_workcenter.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import models, fields
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
 
 
 class MrpWorkcenter(models.Model):
@@ -16,6 +17,26 @@ class MrpWorkcenter(models.Model):
         inverse_name="workcenter_id",
         string="Positions",
     )
+
+    @api.constrains("multiplier_piece")
+    def _check_multiplier(self):
+        for rec in self:
+            if not rec.multiplier_piece:
+                raise UserError(
+                    _("Multiplier / Piece must be greater than zero."))
+
+    @api.constrains("position_ids")
+    def _check_position_ids(self):
+        for rec in self:
+            if not rec.position_ids:
+                raise UserError(_("You must add at least one position in "
+                                  "this work center."))
+
+    @api.model
+    def create(self, values):
+        if "position_ids" not in values:
+            values["position_ids"] = False
+        return super().create(values)
 
 
 class MrpWorkcenterPosition(models.Model):

--- a/custom-addons/mason_mrp_workorder/models/mrp_workorder.py
+++ b/custom-addons/mason_mrp_workorder/models/mrp_workorder.py
@@ -1,7 +1,8 @@
 # Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import models, fields
+from odoo import models, fields, _
+from odoo.exceptions import UserError
 
 
 class MrpWorkorder(models.Model):
@@ -12,6 +13,17 @@ class MrpWorkorder(models.Model):
         inverse_name="workorder_id",
         string="Man Quantity",
     )
+
+    def _check_man_ids(self):
+        for rec in self:
+            if not rec.man_ids:
+                raise UserError(_("You must add at least one man in "
+                                  "this work order."))
+
+    def do_finish(self):
+        action = super().do_finish()
+        self._check_man_ids()
+        return action
 
 
 class MrpWorkorderMan(models.Model):

--- a/custom-addons/mason_mrp_workorder/views/mrp_workcenter_views.xml
+++ b/custom-addons/mason_mrp_workorder/views/mrp_workcenter_views.xml
@@ -5,10 +5,12 @@
         <field name="inherit_id" ref="mrp.mrp_workcenter_view"/>
         <field name="arch" type="xml">
             <xpath expr="//notebook/page/group/group[3]" position="after">
-                <field name="multiplier_piece"/>
+                <group>
+                    <field name="multiplier_piece" required="1" groups="mrp.group_mrp_manager"/>
+                </group>
             </xpath>
             <xpath expr="//notebook" position="inside">
-                <page string="Positions">
+                <page string="Positions" groups="mrp.group_mrp_manager">
                     <field name="position_ids">
                         <tree editable="bottom">
                             <field name="name"/>

--- a/custom-addons/mason_production_statistic/__init__.py
+++ b/custom-addons/mason_production_statistic/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from . import wizards
+from . import models

--- a/custom-addons/mason_production_statistic/__manifest__.py
+++ b/custom-addons/mason_production_statistic/__manifest__.py
@@ -2,19 +2,20 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
 {
-    "name": "Mason :: MRP II",
+    "name": "Mason :: Production Statistic",
     "version": "13.0.1.0.0",
     "category": "Manufacturing/Manufacturing",
     "description": """
-        Mason extension for MRP which inherited from mrp_workorder module.
+        This is add production statistic menu.
     """,
     "depends": [
-        "mrp_workorder",
+        "mason_mrp_workorder",
     ],
     "data": [
         "security/ir.model.access.csv",
-        "views/mrp_workcenter_views.xml",
-        "views/mrp_workorder_views.xml",
+        "wizards/production_statistic_wizard_views.xml",
+        "wizards/confirm_default_wizard_views.xml",
+        "views/production_statistic_views.xml",
     ],
     "application": False,
     "license": "AGPL-3",

--- a/custom-addons/mason_production_statistic/models/__init__.py
+++ b/custom-addons/mason_production_statistic/models/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from . import mrp_workorder
+from . import production_statistic

--- a/custom-addons/mason_production_statistic/models/mrp_workorder.py
+++ b/custom-addons/mason_production_statistic/models/mrp_workorder.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import models
+from datetime import timedelta
+
+
+class MrpWorkorder(models.Model):
+    _inherit = "mrp.workorder"
+
+    def _prepare_production_statistic(self):
+        self.ensure_one()
+        actual_hours = timedelta(minutes=self.duration).total_seconds() / 3600
+        qty_per_day = self.qty_produced * 8 / actual_hours
+        total_labor_cost = sum(
+            [l.qty_man * l.position_id.labor_cost_day for l in self.man_ids])
+        multiplier = self.workcenter_id.multiplier_piece
+        labor_cost_piece = total_labor_cost / qty_per_day * multiplier
+        return {
+            "product_id": self.product_id.id,
+            "origin": self.production_id.origin,
+            "production_id": self.production_id.id,
+            "workcenter_id": self.workcenter_id.id,
+            "qty_per_day": qty_per_day,
+            "multiplier": multiplier,
+            "labor_cost_piece": labor_cost_piece,
+            "type": "system",
+            "approved_id": self.env.ref("base.user_root").id,
+        }
+
+    def _create_production_statistic(self):
+        vals = []
+        for rec in self:
+            vals.append(rec._prepare_production_statistic())
+        prod_stat = self.env["production.statistic"].with_user(
+            self.env.ref("base.user_root")).create(vals)
+        return prod_stat
+
+    def do_finish(self):
+        action = super().do_finish()
+        self._create_production_statistic()
+        return action

--- a/custom-addons/mason_production_statistic/models/production_statistic.py
+++ b/custom-addons/mason_production_statistic/models/production_statistic.py
@@ -1,0 +1,114 @@
+# Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+
+class ProductionStatistic(models.Model):
+    _name = "production.statistic"
+    _description = "Production Statistic"
+    _order = "create_date"
+
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product",
+        default=lambda self: self._context.get("product_id"),
+        ondelete="restrict",
+        required=True,
+        index=True,
+    )
+    origin = fields.Char(
+        string="SO",
+    )
+    production_id = fields.Many2one(
+        comodel_name="mrp.production",
+        string="MO",
+        ondelete="restrict",
+        index=True,
+    )
+    workcenter_id = fields.Many2one(
+        comodel_name="mrp.workcenter",
+        string="Work Center",
+        default=lambda self: self._context.get("workcenter_id"),
+        ondelete="restrict",
+        required=True,
+        index=True,
+    )
+    qty_per_day = fields.Float(
+        string="Quantity / Day",
+        digits=(25, 10),
+        default=0.0,
+    )
+    multiplier = fields.Float(
+        string="Multiplier",
+        default=lambda self: self._get_default_multiplier(),
+    )
+    labor_cost_piece = fields.Float(
+        string="Labor Cost / Piece",
+        digits=(25, 10),
+        default=0.0,
+    )
+    default = fields.Boolean(
+        string="Default",
+        default=False,
+    )
+    type = fields.Selection(
+        selection=[
+            ("system", "System"),
+            ("adjustment", "Adjustment"),
+        ],
+        string="Type",
+        default="adjustment",
+        required=True,
+    )
+    approved_id = fields.Many2one(
+        comodel_name="res.users",
+        string="Approved",
+        default=lambda self: self.env.user,
+        ondelete="restrict",
+        required=True,
+        index=True,
+    )
+    note = fields.Text(
+        string="Note",
+    )
+    confirm = fields.Boolean(
+        string="Confirm",
+        default=False,
+    )
+
+    @api.model
+    def _get_default_multiplier(self):
+        multiplier = 0.0
+        workcenter_id = self._context.get("workcenter_id")
+        if workcenter_id:
+            workcenter = self.env["mrp.workcenter"].browse(workcenter_id)
+            multiplier = workcenter.multiplier_piece
+        return multiplier
+
+    @api.model
+    def create(self, values):
+        res = super().create(values)
+        if res.type == "adjustment":
+            return res
+        prod_stat = self.search([
+            ("product_id", "=", res.product_id.id),
+            ("workcenter_id", "=", res.workcenter_id.id),
+            ("default", "=", True)])
+        if not prod_stat:
+            res.default = True
+        else:
+            if res.labor_cost_piece < prod_stat.labor_cost_piece:
+                prod_stat.default = False
+                res.default = True
+        return res
+
+    def unlink(self):
+        for rec in self:
+            if rec.type == "system":
+                raise UserError(_("You cannot delete a system type."))
+            if rec.confirm:
+                raise UserError(_(
+                    "You cannot delete a adjustment type as confirm already."))
+        return super().unlink()

--- a/custom-addons/mason_production_statistic/security/ir.model.access.csv
+++ b/custom-addons/mason_production_statistic/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_production_statistic_manager,production.statistic.manager,model_production_statistic,mrp.group_mrp_manager,1,1,1,1

--- a/custom-addons/mason_production_statistic/views/production_statistic_views.xml
+++ b/custom-addons/mason_production_statistic/views/production_statistic_views.xml
@@ -1,0 +1,36 @@
+<odoo>
+    <record id="production_statistic_view_tree" model="ir.ui.view">
+        <field name="name">production.statistic.view.tree</field>
+        <field name="model">production.statistic</field>
+        <field name="arch" type="xml">
+            <tree editable="bottom" decoration-danger="type == 'adjustment' and not confirm">
+                <field name="product_id" readonly="1" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                <field name="origin" readonly="1"/>
+                <field name="production_id" readonly="1" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                <field name="workcenter_id" readonly="1" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                <field name="qty_per_day" attrs="{'readonly': ['|', ('type', '=', 'system'), ('confirm', '=', True)]}"/>
+                <field name="multiplier" readonly="1"/>
+                <field name="labor_cost_piece" attrs="{'readonly': ['|', ('type', '=', 'system'), ('confirm', '=', True)]}"/>
+                <field name="default" readonly="1"/>
+                <button name="%(confirm_default_wizard_action)d" string="Confirm" type="action" icon="fa-check-circle" attrs="{'invisible': ['|', ('type', '!=', 'adjustment'), ('confirm', '=', True)]}"/>
+                <field name="type" readonly="1"/>
+                <field name="approved_id" readonly="1" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                <field name="note" attrs="{'readonly': ['|', ('type', '=', 'system'), ('confirm', '=', True)]}"/>
+                <field name="confirm" invisible="1"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="production_statistic_view_search" model="ir.ui.view">
+        <field name="name">production.statistic.view.search</field>
+        <field name="model">production.statistic</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="origin"/>
+                <field name="production_id"/>
+                <separator/>
+                <filter string="Default" name="default" domain="[('default', '=', True)]"/>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/custom-addons/mason_production_statistic/wizards/__init__.py
+++ b/custom-addons/mason_production_statistic/wizards/__init__.py
@@ -1,0 +1,4 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from . import production_statistic_wizard
+from . import confirm_default_wizard

--- a/custom-addons/mason_production_statistic/wizards/confirm_default_wizard.py
+++ b/custom-addons/mason_production_statistic/wizards/confirm_default_wizard.py
@@ -1,0 +1,25 @@
+# Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import models, _
+from odoo.exceptions import UserError
+
+
+class ConfirmDefaultWizard(models.TransientModel):
+    _name = "confirm.default.wizard"
+    _description = "Confirm Default Wizard"
+
+    def confirm(self):
+        self.ensure_one()
+        active_id = self._context.get("active_id")
+        active_model = self._context.get("active_model")
+        if active_model != "production.statistic":
+            raise UserError(_("Can not open this wizard with object %s") % (
+                active_model, ))
+        active_record = self.env[active_model].browse(active_id)
+        prod_stat = self.env[active_model].search([
+            ("product_id", "=", active_record.product_id.id),
+            ("workcenter_id", "=", active_record.workcenter_id.id),
+            ("default", "=", True)])
+        prod_stat.write({"default": False})
+        active_record.write({"default": True, "confirm": True})

--- a/custom-addons/mason_production_statistic/wizards/confirm_default_wizard_views.xml
+++ b/custom-addons/mason_production_statistic/wizards/confirm_default_wizard_views.xml
@@ -1,0 +1,23 @@
+<odoo>
+    <record id="confirm_default_wizard_view_form" model="ir.ui.view">
+        <field name="name">confirm.default.wizard.view.form</field>
+        <field name="model">confirm.default.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <p>Are you sure to confirm the default value ?</p>
+                <footer>
+                    <button name="confirm" string="Confirm" type="object" default_focus="1" class="oe_highlight"/>
+                    or
+                    <button string="Cancel" class="oe_link" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="confirm_default_wizard_action" model="ir.actions.act_window">
+        <field name="name">Confirmation</field>
+        <field name="res_model">confirm.default.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+</odoo>

--- a/custom-addons/mason_production_statistic/wizards/production_statistic_wizard.py
+++ b/custom-addons/mason_production_statistic/wizards/production_statistic_wizard.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import models, fields, api, _
+
+
+class ProductionStatisticWizard(models.TransientModel):
+    _name = "production.statistic.wizard"
+    _description = "Production Statistic Wizard"
+
+    product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Product",
+        domain=lambda self: self._get_domain_product_id(),
+        index=True,
+    )
+    workcenter_id = fields.Many2one(
+        comodel_name="mrp.workcenter",
+        string="Work Center",
+        index=True,
+    )
+
+    @api.model
+    def _get_domain_product_id(self):
+        products = self.env["mrp.workorder"].search([]).mapped("product_id")
+        return "[('id', 'in', %s)]" % (products.ids, )
+
+    def open_production_statistic(self):
+        self.ensure_one()
+        domain = []
+        if self.product_id:
+            domain += [('product_id', '=', self.product_id.id)]
+        if self.workcenter_id:
+            domain += [('workcenter_id', '=', self.workcenter_id.id)]
+        return {
+            "name": _("Production Statistic"),
+            "view_mode": "tree",
+            "res_model": "production.statistic",
+            "type": "ir.actions.act_window",
+            "context": {
+                "product_id": self.product_id.id,
+                "workcenter_id": self.workcenter_id.id,
+            },
+            "domain": domain,
+        }

--- a/custom-addons/mason_production_statistic/wizards/production_statistic_wizard_views.xml
+++ b/custom-addons/mason_production_statistic/wizards/production_statistic_wizard_views.xml
@@ -1,0 +1,37 @@
+<odoo>
+    <record id="production_statistic_wizard_view_form" model="ir.ui.view">
+        <field name="name">production.statistic.wizard.view.form</field>
+        <field name="model">production.statistic.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <group name="criteria">
+                    <group>
+                        <field name="product_id" required="1" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                        <field name="workcenter_id" attrs="{'invisible': [('product_id', '=', False)], 'required': [('product_id', '!=', False)]}" domain="[('order_ids.product_id', '=', product_id)]" options="{'no_create': True, 'no_create_edit': True, 'no_open': True}"/>
+                    </group>
+                    <group></group>
+                </group>
+                <footer>
+                    <button name="open_production_statistic" string="Confirm" type="object" default_focus="1" class="oe_highlight"/>
+                    or
+                    <button string="Cancel" class="oe_link" special="cancel"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+
+    <record id="production_statistic_wizard_action" model="ir.actions.act_window">
+        <field name="name">Production Statistic</field>
+        <field name="res_model">production.statistic.wizard</field>
+        <field name="view_mode">form</field>
+        <field name="target">new</field>
+    </record>
+
+    <menuitem
+        id="production_statistic_wizard_menu"
+        name="Production Statistic"
+        parent="mrp.menu_mrp_bom"
+        action="production_statistic_wizard_action"
+        sequence="100"
+        groups="mrp.group_mrp_manager"/>
+</odoo>


### PR DESCRIPTION
### Constrains
* Work Center
  * Multiplier / Piece must be greater than zero.
  * You must add at least one position in this work center.
* Work Order
  * You must add at least one man in this work order.
* Production Statistic
  * You cannot delete a system type.
  * You cannot delete a adjustment type as confirm already.

### Access rights
* Work Center
  * Multiplier / Piece, Positions tab << Administrator Group
* Work Order
  * Man tab << User Group
* Production Statistic Menu
  * Can see only Administrator Group

### Production statistic (Field)
* Product (**Required**)
* SO
* MO
* Work Center (**Required**)
* Quantity / Day
* Multiplier
* Labor Cost / Piece
* Default
* Type (**Required**)
* Approved (**Required**)
* Note

### Create production statistic
* Create from WO when you click "MARK AS DONE"
  * Type "System"
  * Approved "OdooBot"
  * Readonly record
* Create directly (Case adjustment type)
  * Type "Adjustment"
  * Approved "Current user login"
  * You can fill in Quantity / Day, Labor Cost / Piece, Default, Note

### Search production statistic
* Search by SO and MO
* Filter Is Default